### PR TITLE
Cache 1 arc second resolution earth relief grid

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,1 +1,2 @@
 conda run gmt grdimage @earth_relief_01m -R=OC -JEPSG:4326 > /dev/null
+rm gmt.history

--- a/postBuild
+++ b/postBuild
@@ -1,2 +1,1 @@
-conda run gmt grdimage @earth_relief_01m -R=OC -JEPSG:4326 > /dev/null
-rm gmt.history
+conda run gmt which -Gu @earth_relief_01m

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,1 @@
+conda run gmt grdimage @earth_relief_01m -R=OC -JEPSG:4326 > /dev/null


### PR DESCRIPTION
Saves workshop users from having to all wait for a 214MB file download at the same time, and also mitigates against possibility of GMT server being down at a bad time. For anyone interested, the postBuild script runs `grdimage` with region (R) Oceania and projection (J) EPSG:4326.