### PR TITLE
Bump gmt from version 6.0.0rc5 to 6.0.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,8 @@
 name: foss4g2019oceania
 channels:
   - conda-forge
-  - conda-forge/label/dev
 dependencies:
-  - gmt==6.0.0rc5
+  - gmt==6.0.0
   - pip==19.*
   - pip:
     - https://github.com/GenericMappingTools/pygmt/archive/master.zip


### PR DESCRIPTION
GMT 6.0.0 is finally released so we can install it directly from the main conda-forge channel (instead of dev). Cross referencing https://github.com/GenericMappingTools/pygmt/pull/363,