### PR TITLE
Tutorial 1: Introduction to PyGMT for GeoScientists

### DIFF
--- a/1_introduction.ipynb
+++ b/1_introduction.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# **1. An introduction to [PyGMT](https://www.pygmt.org) for GeoScientists**\n",
+    "\n",
+    "Welcome to the workshop!\n",
+    "Here in this [jupyter lab](https://jupyterlab.readthedocs.io) environment,\n",
+    "we'll go through some of the basics of loading the PyGMT library into Python,\n",
+    "and have a go at making some simple figures!\n",
+    "\n",
+    "[PyGMT](https://www.pygmt.org/) is a [PyData](https://pydata.org/)\n",
+    "compatible package for analyzing and plotting time-series and gridded data.\n",
+    "It is an [open source](https://github.com/GenericMappingTools/pygmt) Python package\n",
+    "that aims to provide a more accessible interface to the popular\n",
+    "[Generic Mapping Tools](https://www.generic-mapping-tools.org) (GMT) library\n",
+    "used by Earth, Ocean and Planetary scientists worldwide.\n",
+    "\n",
+    "If you encounter any problems, feel free to post a question on our\n",
+    "[forum](https://forum.generic-mapping-tools.org/).\n",
+    "Feature requests and bug reports are also welcome, just raise it as a\n",
+    "[Github issue](https://github.com/GenericMappingTools/pygmt/issues/new/choose)\n",
+    "and we'll try to sort it out as soon as possible!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Getting started**\n",
+    "\n",
+    "We've done all the hard work [installing PyGMT](https://www.pygmt.org/dev/install) for you already.\n",
+    "So simply import the `pygmt` Python package, and that will give you access to\n",
+    "all the data processing and plotting modules.\n",
+    "\n",
+    "Tip: Press `Shift+Enter` to run a code 'cell',\n",
+    "or click on the Play ► button above.\n",
+    "You can also add new cells using the Plus + button."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pygmt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To make sure that things work, let's plot the GMT logo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = pygmt.Figure()\n",
+    "fig.logo(D=\"x0/0+w3c\")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Did it work?\n",
+    "If yes, then great!\n",
+    "In the following sections, we'll break things down step by step so you can follow along."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Making a map**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All figure generation in PyGMT is handled by the\n",
+    "[pygmt.Figure](https://www.pygmt.org/dev/api/generated/pygmt.Figure.html) class.\n",
+    "It has methods to add layers to your figure, like a basemap, coastlines, etc.\n",
+    "\n",
+    "Start a new figure by creating a blank instance of `pygmt.Figure`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = pygmt.Figure()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We gradually add layer elements to the figure using its methods.\n",
+    "Let's start by creating a [basemap](https://www.pygmt.org/dev/api/generated/pygmt.Figure.basemap)\n",
+    "focused on New Zealand with the following options:\n",
+    "\n",
+    "- set the `region` to a suitable bounding box in the form of `[xmin, xmax, ymin, ymax]`.\n",
+    "- set the [`projection`](https://www.pygmt.org/dev/projections/) to Universal Transverse Mercator (U),\n",
+    "  and make the map 6 cm wide.\n",
+    "- set the map `frame` to have automatic tick marks using `True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.basemap(region=[165, 180, -49, -33], projection=\"U6c\", frame=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we'll use [coast](https://www.pygmt.org/dev/api/generated/pygmt.Figure.coast) to colour the land darkgreen and water lightblue.\n",
+    "You can find the full list of colour options [here](https://docs.generic-mapping-tools.org/latest/gmtcolors.html#list-of-colors)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.coast(land=\"darkgreen\", water=\"lightblue\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then preview the figure directly in Jupyter using `show`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a fairly simple example, but you will find out that GMT is much more powerful than that!\n",
+    "Find out more about tweaking the coastline and borders at this\n",
+    "[tutorial](https://www.pygmt.org/dev/tutorials/coastlines.html).\n",
+    "\n",
+    "For now though, let's proceed and see how we can add more colour to our map!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **What a (colourful) relief**\n",
+    "\n",
+    "As geoscientists, we're often interested in the Earth's terrain,\n",
+    "and a Digital Elevation Model (DEM) is a common element in many maps.\n",
+    "\n",
+    "Let's have a go at making a map of Oceania showing the ocean bathymetry and land elevation.\n",
+    "We'll start by setting our `basemap` to focus on the Oceania region (=OC).\n",
+    "Our map frame will have tick marks at major and minor intervals (af),\n",
+    "and x and y axis labels on the 'W'est and 'S'outh sides only (WSne)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = pygmt.Figure()\n",
+    "fig.basemap(region=\"=OC\", frame=[\"af\", \"WSne\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "GMT6 comes with a global Earth relief model ([SRTM15+V2](https://doi.org/10.1029/2019EA000658))\n",
+    "that can be accessed using special filenames like '@earth_relief_xxx'.\n",
+    "Here, we'll plot the 1 arc minute grid using [fig.grdimage](https://www.pygmt.org/dev/api/generated/pygmt.Figure.grdimage),\n",
+    "and explicitly use the 'geo' colormap to colour the terrain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.grdimage(grid=\"@earth_relief_01m\", cmap=\"geo\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll also add a [colorbar](https://www.pygmt.org/dev/api/generated/pygmt.Figure.colorbar) for good measure.\n",
+    "The `position` is set to be outside the map frame (J), at the Middle Right (MR) side.\n",
+    "The colorbar will automatically pick up the last colormap we used above,\n",
+    "but we can force the units to be in kilometres instead of the default metres using `cmap=\"+Uk\"`.\n",
+    "We'll also use `frame` to add annotated tick marks at suitable intervals to the colorbar (af),\n",
+    "and set the label to be in units km (+lkm)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.colorbar(position=\"JMR\", cmap=\"+Uk\", frame=[\"af\", \"y+lkm\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we call `show` again to display our map!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Exploration time - Make a map of where you came from!**\n",
+    "\n",
+    "Take some time to produce a map of your own. Below are some ideas on what you can do.\n",
+    "\n",
+    "Changing the **region** and grid **resolution**:\n",
+    "\n",
+    "- You can change the country/territory in the `region` argument to another 2 letter code by\n",
+    "  following the [ISO 3166-1 alpha-2 convention](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements).\n",
+    "  e.g. `region=\"NZ\"` for New Zealand.\n",
+    "- If your region is interest is small (e.g. for a Pacific island) and the grid looks blocky,\n",
+    "  try using a higher resolution grid e.g. `grid=\"@earth_relief_30s\"` with 30 arc second pixels\n",
+    "  (warning, this will take some time to download!).\n",
+    "- Advanced users can fine-tune the bounding box region by looking at https://docs.generic-mapping-tools.org/latest/gmt.html#r-full!\n",
+    "\n",
+    "Pick another **colormap** and add a **hillshade**:\n",
+    "\n",
+    "- Choose a different cmap, check out GMT's full suite of [built-in color palette tables](https://docs.generic-mapping-tools.org/latest/cookbook/cpts.html#built-in-color-palette-tables-cpt).\n",
+    "- Try passing in `shading=True` into `fig.grdimage()` to get a nice hillshaded terrain map!\n",
+    "\n",
+    "Add a **title** to your map!\n",
+    "\n",
+    "- Set a title by adding an extra entry to your basemap's `frame` like so `frame=[\"af\", \"+tMyTitle\"]`.\n",
+    "  If your title has spaces, you'll need to enclose it in quotes like this `'+t\"My Title\"'`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = pygmt.Figure()\n",
+    "# <CODE HERE>\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Saving your figure**\n",
+    "\n",
+    "Finally, use the [fig.savefig](https://www.pygmt.org/dev/api/generated/pygmt.Figure.savefig) method (based on the matplotlib function) to save your figure to a file.\n",
+    "You can export it formats like PNG, PDF, EPS and so on,\n",
+    "and set the raster resolution in dots per inch (dpi) if so desired.\n",
+    "\n",
+    "Tip: Hit `Shift+Tab` while your cursor is in the brackets of `fig.savefig()` to see the documentation for that function!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.savefig(\"map_of_somewhere.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The saved figure will appear on the file list on the left.\n",
+    "Since everything here lives on the 'cloud', you should probably download\n",
+    "the figure and jupyter notebook (.ipynb) file to your own computer.\n",
+    "Right click on any file you want and there should be a 'Download' option.\n",
+    "\n",
+    "As we go along these tutorials,\n",
+    "keep in mind to save and download your work every once in a while.\n",
+    "Next up, we'll start to do some data processing tasks,\n",
+    "loading in points from [pandas](rid=@earth_relief_30s) and\n",
+    "work with grids using [xarray](rid=@earth_relief_30s)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/1_introduction.ipynb
+++ b/1_introduction.ipynb
@@ -325,8 +325,8 @@
     "As we go along these tutorials,\n",
     "keep in mind to save and download your work every once in a while.\n",
     "Next up, we'll start to do some data processing tasks,\n",
-    "loading in points from [pandas](rid=@earth_relief_30s) and\n",
-    "work with grids using [xarray](rid=@earth_relief_30s)."
+    "loading in points from [pandas](https://pandas.pydata.org) and\n",
+    "work with grids using [xarray](http://xarray.pydata.org)."
    ]
   }
  ],


### PR DESCRIPTION
Covers the basics of importing PyGMT into Python, and making a simple map (of New Zealand). Then we learn to plot a map of Oceania using the earth relief grids, and workshop users will have a chance to explore making a map of where they came from. Also covers saving the figure and jupyter notebook.

Test branch using binder like below:

[![Binder](https://binder.pangeo.io/badge_logo.svg)](https://binder.pangeo.io/v2/gh/weiji14/foss4g2019oceania/tutorial/1_introduction?filepath=1_introduction.ipynb)