### PR TITLE
Update to jupyterlab 1.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,5 +4,6 @@ channels:
 dependencies:
   - gmt==6.0.0
   - pip==19.*
+  - jupyterlab==1.2.*
   - pip:
     - https://github.com/GenericMappingTools/pygmt/archive/master.zip


### PR DESCRIPTION
Explicitly adding [jupyterlab](https://jupyterlab.readthedocs.io) dependency, in case anyone wants to copy the environment.yml file. Also it's a newer version than the 0.35.4 (released a year ago in Nov 2018) that comes with Pangeo Binder.

Test Binder button:

[![Binder](https://binder.pangeo.io/badge_logo.svg)](https://binder.pangeo.io/v2/gh/GenericMappingTools/foss4g2019oceania/jupyterlab/1.2)