### PR TITLE
Add rasterio 1.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - gmt==6.0.0
-  - pip==19.*
   - jupyterlab==1.2.*
+  - pip==19.*
+  - rasterio==1.1.*
   - pip:
     - https://github.com/GenericMappingTools/pygmt/archive/master.zip


### PR DESCRIPTION
Needed for reading in GeoTIFF (.tif) files standard in geospatial applications. Repository at https://github.com/mapbox/rasterio.