### PR TITLE
Tutorial 2: PyData and PyGMT - plotting data on maps

### DIFF
--- a/2_pydata_and_pygmt.ipynb
+++ b/2_pydata_and_pygmt.ipynb
@@ -1,0 +1,394 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# **2. PyData and PyGMT - plotting data on maps**\n",
+    "\n",
+    "In this tutorial, we'll be using tools from the [PyData](https://pydata.org) ecosystem's stack\n",
+    "to load in point and grid datasets via\n",
+    "[pandas](https://pandas.pydata.org) and [xarray](http://xarray.pydata.org) respectively.\n",
+    "We will then learn how to plot these on a map via [PyGMT](https://www.pygmt.org).\n",
+    "Those familiar with [matplotlib](https://matplotlib.org) will find the syntax to be rather similar,\n",
+    "but [PyGMT](https://www.pygmt.org/dev/overview) has a greater focus on producing high quality vector graphic maps\n",
+    "for publications, posters, talks, etc that is more suited for a geospatial audience."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Getting started**\n",
+    "\n",
+    "We'll start by importing the Python libraries we'll be using.\n",
+    "Following common conventions, we'll abbreviate\n",
+    "[pandas](https://pandas.pydata.org) as `pd` and\n",
+    "[xarray](http://xarray.pydata.org) as `xr`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import pygmt\n",
+    "import xarray as xr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **2.1 Loading and plotting points**\n",
+    "\n",
+    "Now let's have a go at plotting our earthquake points on a map!\n",
+    "GMT really shines when it comes to plotting data on a map.\n",
+    "\n",
+    "We'll use pandas to read in a CSV file of historical earthquakes from October 2018 to 2019\n",
+    "directly via the [GeoNet Quake Search](https://quakesearch.geonet.org.nz) API kindly provided\n",
+    "by the New Zealand GeoNet project and its sponsors EQC, GNS Science and LINZ.\n",
+    "Alternatively, you can read in your own csv file by passing in the path to a local file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "quakes = pd.read_csv(\n",
+    "    \"https://quakesearch.geonet.org.nz/csv?minmag=4&bbox=160,-50,185,-10&startdate=2018-10-01T0:00:00&enddate=2019-10-31T1:00:00\",\n",
+    "    skipinitialspace=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can preview the first few columns of the pandas.DataFrame\n",
+    "to see what the earthquake data looks like."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "quakes.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's start a new figure by creating a blank instance of `pygmt.Figure`,\n",
+    "this time though, we'll set our focus to Fiji (FJ) instead.\n",
+    "We'll also use [pygmt.Figure.text](https://www.pygmt.org/dev/api/generated/pygmt.Figure.text)\n",
+    "to plot the country's capital Suva at a suitable coordinate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = pygmt.Figure()\n",
+    "fig.basemap(region=\"FJ\", frame=True)\n",
+    "fig.coast(land=\"grey\", water=\"lightblue\")\n",
+    "fig.text(x=178.4, y=-18.2, text=\"Suva\", font=\"12p,Helvetica-Bold,black\")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The [pygmt.Figure.plot](https://www.pygmt.org/dev/api/generated/pygmt.Figure.plot) method\n",
+    "is used to plot the points.\n",
+    "\n",
+    "You'll notice that our \"quakes\" table has 'longitude' and 'latitude' columns,\n",
+    "and we'll pass those into the `x` and `y` arguments of `plot`.\n",
+    "We set the `style` as 'c0.3c' which means circles of 0.3 cm in size,\n",
+    "The `pen` attribute controls the outline of the symbols and `color` controls the fill."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.plot(x=quakes.longitude, y=quakes.latitude, style=\"c0.3c\", pen=\"black\", color=\"orange\")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **Changing the colour of points**\n",
+    "\n",
+    "We can also colour the circles according to the earthquake's magnitude.\n",
+    "Let's start by creating a new `pygmt.Figure` once more."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = pygmt.Figure()\n",
+    "fig.basemap(region=\"FJ\", frame=[\"af\", '+t\"Earthquakes near Fiji\"'])\n",
+    "fig.coast(land=\"grey\", water=\"lightblue\")\n",
+    "fig.text(x=178.4, y=-18.2, text=\"Suva\", font=\"12p,Helvetica-Bold,black\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we'll create a color palette table (cpt) using\n",
+    "[pygmt.makecpt](https://www.pygmt.org/dev/api/generated/pygmt.makecpt),\n",
+    "scaling it to an appropriate range or `series`, which is about 3.5 to 6.5 in this case.\n",
+    "We need to do this because most of GMT's\n",
+    "[built-in color palette tables](https://docs.generic-mapping-tools.org/latest/cookbook/cpts.html#built-in-color-palette-tables-cpt)\n",
+    "assume a data range of values between 0 and 1,\n",
+    "and our earthquake magnitudes fall outside of that range.\n",
+    "\n",
+    "We'll use the [scientific colourmap](http://www.fabiocrameri.ch/colourmaps.php) 'batlow' here,\n",
+    "but feel free to explore other alternatives for your own use case!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pygmt.makecpt(cmap=\"batlow\", series=[3.5, 6.5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After that, we then tell [pygmt.Figure.plot](https://www.pygmt.org/dev/api/generated/pygmt.Figure.plot)\n",
+    "to `color` the points using the 'magnitude' values.\n",
+    "GMT will automatically use the scaled cpt we just made if we setting `cmap` to True."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.plot(x=quakes.longitude, y=quakes.latitude, color=quakes.magnitude, style=\"c0.3c\", cmap=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lastly, we'll set a colorbar on the Bottom Center (BC) with an appropriate label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.colorbar(position=\"JBC\", frame=[\"af\", \"y+lMagnitude\"])\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are many other ways we can improve the display of points and other vector datasets on a map.\n",
+    "For example, you can follow this [tutorial](https://www.pygmt.org/dev/tutorials/plot.html#plotting-data-points)\n",
+    "to change the size of the points depending on the earthquake's magnitude.\n",
+    "There are also some [PyGMT gallery examples](https://www.pygmt.org/dev/gallery/index.html#plotting-map-items)\n",
+    "and pure [GMT gallery examples](https://docs.generic-mapping-tools.org/latest/gallery.html) you can\n",
+    "refer to for more inspiration.\n",
+    "\n",
+    "We'll leave it here for now,\n",
+    "but just realize that [pygmt.Figure.plot](https://www.pygmt.org/dev/api/generated/pygmt.Figure.plot)\n",
+    "is a very powerful tool that can used for plotting lines, polygons and other symbols,\n",
+    "for not only maps but also non-geographic 2D plots as well!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **2.2 Loading and plotting grids**\n",
+    "\n",
+    "Now let's have a go at plotting some raster grids again!\n",
+    "\n",
+    "This time though, we'll use [xarray](http://xarray.pydata.org) and [rasterio](https://github.com/mapbox/rasterio)\n",
+    "to load in a seamless 10 m spatial resolution bathymetry and topography DEM of Sydney Harbour\n",
+    "(published under a [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/) license\n",
+    "by [Wilson and Power, 2018](https://doi.org/10.1594/PANGAEA.885014)).\n",
+    "The file is in an ESRI ASCII Raster format, but the workflow will be very similar for\n",
+    "[GeoTIFF](https://en.wikipedia.org/wiki/GeoTIFF) and [NetCDF](https://en.wikipedia.org/wiki/NetCDF) files,\n",
+    "or any of the file formats which xarray/rasterio can read in.\n",
+    "\n",
+    "Note: The filename below looks funny because we're reading it directly from the web,\n",
+    "and unzipping the zip file 'on the fly' to get at the file we want\n",
+    "(see [here](https://rasterio.readthedocs.io/en/stable/topics/datasets.html#advanced-datasets) for more info).\n",
+    "Alternatively, you can substitute the filename to the path of a dataset stored locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid = xr.open_rasterio(\n",
+    "    filename=\"zip+https://store.pangaea.de/Publications/WilsonK_etal_2018/Sydney.zip!Sydney/syd_10m_utm56.txt\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can preview the resulting xarray.DataArray to look at some of the metadata and attributes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "PyGMT's [grdimage](https://www.pygmt.org/dev/api/generated/pygmt.Figure.grdimage) function\n",
+    "requires the grid to only have 2 dimensions (i.e. x and y),\n",
+    "but our grid currently has 3 (band, x and y) as denoted by the asterisk *.\n",
+    "We'll need to select just one of the bands (number 1 in this case)\n",
+    "so that things will work properly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid = grid.sel(band=1)\n",
+    "grid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next steps are just some additional preprocessing.\n",
+    "We'll remove the NaN values so that they don't get plotted,\n",
+    "and also sort our grid so that the x and y dimensions\n",
+    "go in ascending order (i.e. West to East, South to North)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid = grid.where(grid != grid.nodatavals, drop=True)\n",
+    "grid = grid.sortby(variables=list(grid.dims))\n",
+    "grid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we can make our plot!\n",
+    "We'll create a color palette table (cpt) scaled to our minimum and maximum elevation.\n",
+    "Our colobar will be plotted on the Middle Right (MR) side with an X-offset of 1 cm,\n",
+    "and there will be a little square showing the NaN color (+n)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = pygmt.Figure()\n",
+    "pygmt.makecpt(series=[float(grid.min()), float(grid.max())], cmap=\"geo\")\n",
+    "fig.grdimage(grid=grid, frame=[\"af\", 'WSne+t\"Sydney Harbour Topography\"'])\n",
+    "fig.colorbar(position=\"JMR+n\", frame=[\"af\", 'y+l\"Elevation (m)\"'], X=\"1c\")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Additional Notes**\n",
+    "\n",
+    "PyGMT currently has a few limitations when it comes with plotting grids.\n",
+    "Here is a list of some of the common ones (and their workarounds):\n",
+    "\n",
+    "- The datatype (dtype) of the xarray.DataArray values must be either int/uint/float 32/64,\n",
+    "  (i.e. the standard uint/int16 found in many GeoTiff files won't work out of the box).\n",
+    "  - Workaround: Convert the dtype using `grid = grid.astype(dtype=np.uint32)`\n",
+    "- Large datasets stored in an xarray.DataArray may take a long time for PyGMT to plot.\n",
+    "  - Workaround: Subset your xarray grid using `grid.sel(x=slice(minx, maxx), y=slice(miny, maxy))`\n",
+    "  - Alternative: Pass in the filename to your grid directly, instead of loading it via xarray.\n",
+    "  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So far we've gone through a good chunk of PyGMT's plotting modules,\n",
+    "but there's a whole lot more to PyGMT than that!\n",
+    "Next on, we'll look at one example of PyGMT's data processing functionality.\n",
+    "Specifically, taking a point cloud and processing it into a Digital Elevation Model (DEM) grid!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Using the [PyData](https://pydata.org) stack (specifically pandas and xarray) to load in data, and plot them on maps via [PyGMT](https://www.pygmt.org)! First part involves working with earthquake points pulled from the [GeoNet Quake Search](https://quakesearch.geonet.org.nz) API. Second part pulls in an elevation grid of Sydney Harbour from [Wilson and Power, 2018](https://doi.org/10.1594/PANGAEA.885014).

Pangeo binder button:

[![Binder](https://binder.pangeo.io/badge_logo.svg)](https://binder.pangeo.io/v2/gh/GenericMappingTools/foss4g2019oceania/tutorial/2_pydata_and_pygmt?filepath=2_pydata_and_pygmt.ipynb)