### PR TITLE
Install dependencies for reading lidar and writing to raster files

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,5 +9,6 @@ dependencies:
   - numpy==1.16.*
   - pip==19.*
   - rasterio==1.1.*
+  - rioxarray==0.0.*
   - pip:
     - https://github.com/GenericMappingTools/pygmt/archive/master.zip

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,9 @@ channels:
 dependencies:
   - gmt==6.0.0
   - jupyterlab==1.2.*
+  - laspy==1.6.*
+  - lastools==20171231
+  - numpy==1.16.*
   - pip==19.*
   - rasterio==1.1.*
   - pip:


### PR DESCRIPTION
Getting some LiDAR tools into the show! Installing some of the required dependencies for Tutorial 3:

- [laspy](https://github.com/laspy/laspy) - for reading in LiDAR las/laz files
- [lastools](https://lastools.github.io/) - containes laszip needed by laspy to read in laz (compressed las) files
- [rioxarray](https://github.com/corteva/rioxarray) - for converting an xarray.DataArray to a GeoTIFF file

Also temporarily pinning numpy to version 1.16.* because of laspy issue not being able to read .laz files properly with numpy 1.17.*, see https://github.com/laspy/laspy/issues/112.

Pangeo Binder button:

[![Binder](https://binder.pangeo.io/badge_logo.svg)](https://binder.pangeo.io/v2/gh/GenericMappingTools/foss4g2019oceania/las_to_ras)